### PR TITLE
Add Unlearning Depth Score (UDS) to Benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,8 @@ The approaches fallen into this category use data partition, data augmentation a
 
 [Unlearning Comparator - A visual analytics system for comparative evaluation of machine unlearning methods](https://github.com/gnueaj/Machine-Unlearning-Comparator) [[Paper]](https://arxiv.org/abs/2508.12730) [[Demo]](https://gnueaj.github.io/Machine-Unlearning-Comparator/)
 
+[UDS (Unlearning Depth Score) - A white-box metric that measures unlearning depth via two-stage activation patching on internal hidden states, evaluated on TOFU forget10](https://github.com/gnueaj/unlearning-depth-score) [[Paper]](https://arxiv.org/abs/2605.24614) [[Project Page]](https://gnueaj.github.io/unlearning-depth-score/)
+
 ----------
 **Disclaimer**
 


### PR DESCRIPTION
Adds Unlearning Depth Score (UDS), a white-box metric that measures unlearning
depth via two-stage activation patching on internal hidden states, evaluated
on TOFU forget10 across 150 unlearned Llama-3.2-1B-Instruct models spanning
8 unlearning methods.

Paper: https://arxiv.org/abs/2605.24614
Project Page: https://gnueaj.github.io/unlearning-depth-score/
Code: https://github.com/gnueaj/unlearning-depth-score

It's the first mechanistic metric for unlearning depth, and we thought it'd be
a nice addition to this list. Thank you for maintaining such a great resource
for the unlearning community 😊

Best,
Jaeung