### PR TITLE
ci: check arXiv citations on pull requests

### DIFF
--- a/.github/workflows/citation-check.yml
+++ b/.github/workflows/citation-check.yml
@@ -1,0 +1,15 @@
+name: citation-check
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: greymoth-jp/glovrex-citation-action@v0
+        with:
+          github-token: ${{ github.token }}


### PR DESCRIPTION
This adds one workflow file: .github/workflows/citation-check.yml.

PRs to this repo are often "Add paper: <title>" (for example #80, "Add paper: Beyond Superficial Forgetting: Thorough Unlearning Through Knowledge Density Estimation and Block Re-Insertion"). This workflow reads a PR's body and any changed markdown, checks the arXiv IDs and DOIs it cites against the real record (arXiv's abstract API, DOI content negotiation), and comments if a claimed title doesn't match the real one.

Report-only: fail-on-mismatch defaults to off, so it never blocks a PR by itself.

It reads only that PR's own content. The only outbound calls it makes are to export.arxiv.org and doi.org, to confirm a citation is real.

It uses pull_request_target so the comment lands on PRs from forks too. The action never checks out or runs the PR's code, only reads it through the GitHub API, so the usual pull_request_target risk (running fork code with a privileged token) doesn't apply here.

Known limits are listed at the top of the README, for example pre-2007 arXiv IDs aren't detected.

Real run for reference: https://github.com/greymoth-jp/cjk-failure-corpus/pull/1

Close this if it's not a fit, that's fine.
